### PR TITLE
Fix the pluck provider state logic

### DIFF
--- a/faaspact_verifier/definitions.py
+++ b/faaspact_verifier/definitions.py
@@ -99,4 +99,14 @@ def _pluck_response(raw_response: Dict) -> Response:
 
 
 def _pluck_provider_state(raw_provider_state: Dict) -> ProviderState:
-    return ProviderState(**raw_provider_state)
+    """
+    >>> _pluck_provider_state({'name': 'there is an egg'})
+    ProviderState(descriptor='there is an egg', params=None)
+
+    >>> _pluck_provider_state({'name': 'there is an egg called', 'params': {'name': 'humpty'}})
+    ProviderState(descriptor='there is an egg called', params={'name': 'humpty'})
+    """
+    return ProviderState(
+        descriptor=raw_provider_state['name'],
+        params=raw_provider_state.get('params')
+    )


### PR DESCRIPTION
```
  File "/Users/zhammer/.local/share/virtualenvs/morning-cd-listens-r4Pwiy1b/lib/python3.7/site-packages/faaspact_verifier/definitions.py", line 102, in _pluck_provider_state                                                              
    return ProviderState(**raw_provider_state)
TypeError: __new__() got an unexpected keyword argument 'name'
```